### PR TITLE
fix: deep upload paths are incorrectly resolved (e.g. with keyPrefix …

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -91,7 +91,7 @@ function buildUploadList(files, clientRoot, headerSpec, keyPrefix) {
     const fileRelPath = filePath.replace(clientRoot, '');
     const fileKey = path.normalize(fileRelPath).split(path.sep);
     if (prefix.length) {
-      fileKey.unshift(prefix);
+      fileKey.unshift(...prefix);
     }
     const upload = {
       filePath: filePath,


### PR DESCRIPTION
…'a/b' path resolves to 'a,b')

### Background

[reference to original issue or other discussion]

### Proposed changes

[list of features added and/or changed]

### Proposed reviewers (optional)

[@ mentions of other contributors]
